### PR TITLE
Add option to append the branch name instead of prepending

### DIFF
--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -59,12 +59,14 @@ module Commands
       name               = get("git config --get pivotal.full-name").strip
       integration_branch = get("git config --get pivotal.integration-branch").strip
       only_mine          = get("git config --get pivotal.only-mine").strip
+      append_name        = get("git config --get pivotal.append-name").strip
 
       options[:api_token]          = token              unless token == ""
       options[:project_id]         = id                 unless id == ""
       options[:full_name]          = name               unless name == ""
       options[:integration_branch] = integration_branch unless integration_branch == ""
       options[:only_mine]          = (only_mine != "")  unless name == ""
+      options[:append_name]        = (append_name != "")
     end
 
     def parse_argv(*args)
@@ -75,6 +77,7 @@ module Commands
         opts.on("-n", "--full-name=", "Pivotal Trakcer full name") { |n| options[:full_name] = n }
         opts.on("-b", "--integration-branch=", "The branch to merge finished stories back down onto") { |b| options[:integration_branch] = b }
         opts.on("-m", "--only-mine", "Only select Pivotal Tracker stories assigned to you") { |m| options[:only_mine] = m }
+        opts.on("-a", "--append-name", "whether to append the story id to branch name instead of prepend") { |a| options[:append_name] = a }
         opts.on("-D", "--defaults", "Accept default options. No-interaction mode") { |d| options[:defaults] = d }
         opts.on("-q", "--quiet", "Quiet, no-interaction mode") { |q| options[:quiet] = q }
         opts.on("-v", "--[no-]verbose", "Run verbosely") { |v| options[:verbose] = v }

--- a/lib/commands/pick.rb
+++ b/lib/commands/pick.rb
@@ -36,14 +36,18 @@ module Commands
       put "Updating #{type} status in Pivotal Tracker..."
       if story.update(:owned_by => options[:full_name])
 
-        suffix = ""
+        suffix_or_prefix = ""
         unless options[:quiet] || options[:defaults]
-          put "Enter branch name (will be prepended by #{story.id}) [#{branch_suffix}]: ", false
-          suffix = input.gets.chomp
+          put "Enter branch name (will be #{options[:append_name] ? 'appended' : 'prepended'} by #{story.id}) [#{suffix_or_prefix}]: ", false
+          suffix_or_prefix = input.gets.chomp
         end
-        suffix = branch_suffix if suffix == ""
+        suffix_or_prefix = branch_suffix if suffix_or_prefix == ""
 
-        branch = "#{story.id}-#{suffix}"
+        if options[:append_name]
+          branch = "#{suffix_or_prefix}-#{story.id}"
+        else
+          branch = "#{story.id}-#{suffix_or_prefix}"
+        end
         if get("git branch").match(branch).nil?
           put "Switched to a new branch '#{branch}'"
           sys "git checkout -b #{branch}"

--- a/lib/commands/pick.rb
+++ b/lib/commands/pick.rb
@@ -34,7 +34,7 @@ module Commands
       put "URL:   #{story.url}"
 
       put "Updating #{type} status in Pivotal Tracker..."
-      if story.update(:owned_by => options[:full_name])
+      if story.update(:owned_by => options[:full_name], :current_state => :started)
 
         suffix_or_prefix = ""
         unless options[:quiet] || options[:defaults]

--- a/readme.markdown
+++ b/readme.markdown
@@ -50,6 +50,10 @@ The project id is best placed within your project's git config:
 
     git config -f .git/config pivotal.project-id 88888
 
+If you would rather have the story id appended to the branch name (feature-123456) instead of prepending (123456-feature), you can configue that:
+
+    git config -f .git/config pivotal.append-name true
+
 If you're not interested in storing these options in git, you can pass them into git pivotal as command line arguments.  See the usage guides for more details.
 
 ##TODO

--- a/spec/commands/base_spec.rb
+++ b/spec/commands/base_spec.rb
@@ -100,4 +100,24 @@ describe Commands::Base do
     @pick.run!    
   end
   
+  it "should set the append name flag with the -a option" do
+    @pick = Commands::Base.new(@input, @output,"-a")
+    @pick.options[:append_name].should be_true
+  end
+
+  it "should set the append name flag from git config" do
+    Commands::Base.any_instance.stubs(:get).with("git config --get pivotal.append-name").returns("true")
+    @pick = Commands::Base.new
+    @pick.options[:append_name].should be_true
+  end
+
+  it "should set the append name flag with the --append-name" do
+    @pick = Commands::Base.new(@input, @output, "--append-name")
+    @pick.options[:append_name].should be_true
+  end
+
+  it "should default the append name flag if none is specified" do
+    @pick = Commands::Base.new
+    @pick.options[:append_name].should be_false
+  end
 end


### PR DESCRIPTION
Right now the story id is prepended to the branch name and there is no way to change it. 

I added an option to give option to append the story id instead of prepend

git config -f .git/config pivotal.append-name true
