### PR TITLE
modify finish.rb to use custom commit message in `git merge` which includes story_id

### DIFF
--- a/lib/commands/finish.rb
+++ b/lib/commands/finish.rb
@@ -15,7 +15,7 @@ module Commands
       if story.update(:current_state => finished_state)
         put "Merging #{current_branch} into #{integration_branch}"
         sys "git checkout #{integration_branch}"
-        sys "git merge --no-ff #{current_branch}"
+        sys "git merge --no-ff -m \"[##{story_id}] Merge branch '#{current_branch}' into #{integration_branch}\" #{current_branch}"
 
         put "Removing #{current_branch} branch"
         sys "git branch -d #{current_branch}"

--- a/spec/commands/finish_spec.rb
+++ b/spec/commands/finish_spec.rb
@@ -37,6 +37,10 @@ describe Commands::Finish do
     "#{mock_story_id}-feature-branch-name"
   end
 
+  def integration_branch_name
+    "master"
+  end
+
   before(:each) do
     # stub out git config requests
     Commands::Finish.any_instance.stubs(:get).with { |v| v =~ /git config/ }.returns("")
@@ -91,12 +95,12 @@ describe Commands::Finish do
       end
 
       it "should checkout the developer's integration branch" do
-        @finish.expects(:sys).with("git checkout master")
+        @finish.expects(:sys).with("git checkout #{integration_branch_name}")
         @finish.run!
       end
 
       it "should merge in the story branch" do
-        @finish.expects(:sys).with("git merge --no-ff #{branch_name}")
+        @finish.expects(:sys).with("git merge --no-ff -m \"[##{mock_story_id}] Merge branch '#{branch_name}' into #{integration_branch_name}\" #{branch_name}")
         @finish.run!
       end
 


### PR DESCRIPTION
**Description:**

This change modifies the `git merge` command within `finish.rb` to use a customized commit message when merging.  The commit message is the same as the standard commit message, but with the Pivotal story ID prepended.  Ex: 

```
[#654321] Merge branch '654321-dant_test2' into 123456-dant_test
```

This custom message will allow GitHub's pivotal hook to update the Pivotal story with a merge commit message and a link to the diff on GitHub.  It also seems like a generally good practice to have the story id in the merges back to the integration branch.

More info on GitHub's Pivotal hook at:
- http://pivotallabs.com/users/dan/blog/articles/1304-github-service-hook-for-pivotal-tracker
- https://www.pivotaltracker.com/help/api?version=v3#github_hooks

**Testing Done:**

Ran locally and checked git log:

```
commit 5ea962859725d2d15c609ab34799efa59bd9af6e
Merge: 6f8769e b8641e1
Author: Dan Tehranian <dan@rivermeadow.com>
Date:   Tue Oct 2 10:48:17 2012 -0700

    [#654321] Merge branch '654321-dant_test2' into 123456-dant_test

commit b8641e1b855857d2dfc3a7aab24ff5ec2e8ff85f
Author: Dan Tehranian <dan@rivermeadow.com>
Date:   Tue Oct 2 10:47:52 2012 -0700

    test commit to branch
```
