### PR TITLE
Fixes #39 to allow for a story id to be specified for the pick commands ...

### DIFF
--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -13,7 +13,11 @@ module Commands
       @options = {}
 
       parse_gitconfig
-      parse_argv(*args)
+      remaining = parse_argv(*args)
+
+      if remaining.one?
+        @options[:story_id] = remaining.first
+      end
     end
 
     def put(string, newline=true)
@@ -78,7 +82,7 @@ module Commands
 
     def parse_argv(*args)
       OptionParser.new do |opts|
-        opts.banner = "Usage: git pick [options]"
+        opts.banner = "Usage: git pick [options] [story_id]"
         opts.on("-k", "--api-key=", "Pivotal Tracker API key") { |k| options[:api_token] = k }
         opts.on("-p", "--project-id=", "Pivotal Trakcer project id") { |p| options[:project_id] = p }
         opts.on("-n", "--full-name=", "Pivotal Trakcer full name") { |n| options[:full_name] = n }

--- a/lib/commands/pick.rb
+++ b/lib/commands/pick.rb
@@ -63,14 +63,23 @@ module Commands
       end
     end
 
-  protected
+    protected
 
     def story
       return @story if @story
 
-      conditions = { :story_type => type, :current_state => "unstarted", :limit => 1, :offset => 0 }
-      conditions[:owned_by] = options[:full_name] if options[:only_mine]
-      @story = project.stories.all(conditions).first
+      @story = if options[:story_id]
+                 project.stories.find options[:story_id]
+               else
+                 conditions = {
+                   :story_type => type,
+                   :current_state => "unstarted",
+                   :limit => 1,
+                   :offset => 0
+                 }
+                 conditions[:owned_by] = options[:full_name] if options[:only_mine]
+                 project.stories.all(conditions).first
+               end
     end
   end
 end

--- a/spec/commands/base_spec.rb
+++ b/spec/commands/base_spec.rb
@@ -148,4 +148,14 @@ describe Commands::Base do
     @pick.options[:use_ssl].should be_false
   end
 
+	it "should look up the specific story (by id) if it is given" do
+		@pick = Commands::Base.new(@input, @output, "54321")
+		@pick.options[:story_id].should == "54321"
+	end
+
+	it "should default to no story id" do
+		@pick = Commands::Base.new(@input, @output, "")
+		@pick.options[:story_id].should be_null
+	end
+
 end


### PR DESCRIPTION
...(feature, bug, chore).  Note that although there is nothing stating this, it ignores the only-mine restriction.
